### PR TITLE
route auth/* paths to the worker

### DIFF
--- a/packages/workers-shared/asset-worker/src/configuration.ts
+++ b/packages/workers-shared/asset-worker/src/configuration.ts
@@ -11,6 +11,7 @@ export const normalizeConfiguration = (
 		compatibility_flags: compatibilityOptions.compatibilityFlags,
 		html_handling: configuration?.html_handling ?? "auto-trailing-slash",
 		not_found_handling: configuration?.not_found_handling ?? "none",
+		worker_route: configuration?.worker_route ?? "",
 		redirects: configuration?.redirects ?? {
 			version: 1,
 			staticRules: {},

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -199,8 +199,8 @@ export const canFetch = async (
 	exists: typeof EntrypointType.prototype.unstable_exists
 ): Promise<boolean> => {
 	if (
-		new URL(t14.url).pathname.startsWith("/auth/")
-		  || !(
+		new URL(request.url).pathname.startsWith("/auth/") ||
+		!(
 			flagIsEnabled(
 				configuration,
 				SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING

--- a/packages/workers-shared/asset-worker/src/handler.ts
+++ b/packages/workers-shared/asset-worker/src/handler.ts
@@ -199,7 +199,8 @@ export const canFetch = async (
 	exists: typeof EntrypointType.prototype.unstable_exists
 ): Promise<boolean> => {
 	if (
-		!(
+		new URL(t14.url).pathname.startsWith("/auth/")
+		  || !(
 			flagIsEnabled(
 				configuration,
 				SEC_FETCH_MODE_NAVIGATE_HEADER_PREFERS_ASSET_SERVING

--- a/packages/workers-shared/utils/types.ts
+++ b/packages/workers-shared/utils/types.ts
@@ -62,6 +62,7 @@ export const AssetConfigSchema = z.object({
 			"none",
 		])
 		.optional(),
+	worker_route: z.string().optional(),
 	not_found_handling: z
 		.enum(["single-page-application", "404-page", "none"])
 		.optional(),

--- a/packages/wrangler/src/assets.ts
+++ b/packages/wrangler/src/assets.ts
@@ -470,6 +470,7 @@ export function getAssetsOptions(
 	const assetConfig: AssetConfig = {
 		html_handling: config.assets?.html_handling,
 		not_found_handling: config.assets?.not_found_handling,
+		worker_route: config.assets?.worker_route,
 		// The _redirects and _headers files are parsed in Miniflare in dev and parsing is not required for deploy
 		compatibility_date: config.compatibility_date,
 		compatibility_flags: config.compatibility_flags,

--- a/packages/wrangler/src/config/environment.ts
+++ b/packages/wrangler/src/config/environment.ts
@@ -941,6 +941,7 @@ export type Assets = {
 	 * If false, then respond to requests that match an asset with that asset directly.
 	 * */
 	run_worker_first?: boolean;
+	worker_route?: string;
 };
 
 export interface Observability {


### PR DESCRIPTION
When using the `"not_found_handling": "single-page-application"` configuration we can't implement OAuth flows that need to hit the worker directly.

This hack exposes `auth/` paths for this purpose.

A real fix would allow paths to be specified in the wrangler config.

---

I actually just used `yarn patch @cloudflare/vite-plugin` locally to implement this hack, this PR is just for sharing.

<img width="249" alt="Screenshot 2025-04-16 at 10 03 07 am" src="https://github.com/user-attachments/assets/0d52ddd4-ad01-475c-8902-318edac72602" />

```
var ar = async (t14, e, n, r) => {
  return (
    (tr(n, Kt) &&
      t14.headers.get("Sec-Fetch-Mode") === "navigate"
      && !new URL(t14.url).pathname.startsWith("/auth/")) // <----- hackedy hack
      || (n = { ...n, not_found_handling: "none" }),
    !((await ir(t14, e, n, r)) instanceof ye)
  );
};
```

---

<!--
Please don't delete the checkboxes <3
The following selections do not need to be completed if this PR only contains changes to .md files
-->

- Tests
  - [x] TODO (before merge)
  - [ ] Tests included
  - [ ] Tests not necessary because:
- Wrangler / Vite E2E Tests CI Job required? (Use "e2e" label or ask maintainer to run separately)
  - [x] I don't know
  - [ ] Required
  - [ ] Not required because:
- Public documentation
  - [x] TODO (before merge)
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [x] TODO (before merge)
  - [ ] Wrangler PR: <!--e.g. <https://github.com/cloudflare/workers-sdk/pull/>...-->
  - [ ] Not necessary because: <!--e.g. not a patch change, not a Wrangler change...-->

<!--
Have you read our [Contributing guide](https://github.com/cloudflare/workers-sdk/blob/main/CONTRIBUTING.md)?
In particular, for non-trivial changes, please always engage on the issue or create a discussion or feature request issue first before writing your code.
-->
